### PR TITLE
fix: Updated docs link for community DA tile

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -22,7 +22,8 @@
       ],
       "short_description": "Creates an IBM enterprise account and invite users to the account.",
       "long_description": "This deployable architecture automates the creation of an IBM enterprise account under a parent IBM enterprise and invite users to the new account. Optionally it also creates an account group in order to organize and manage accounts hierarchically and provisions creation of multiple access groups to be assigned to the newly invited users. For more details on IBM enterprise, [see here](https://cloud.ibm.com/docs/enterprise-management?topic=enterprise-management-what-is-enterprise). \n\nLeverage [Terraform IBM Modules](https://github.com/terraform-ibm-modules) to shape and scale your solutions. You can integrate Terraform IBM Modules (TIM) to extend functionality and design a solution tailored to your environment and operations needs. These modules offer reusable, customizable elements that follow IBM Cloud's recommended practices. You can access the [source code and documentation](https://github.com/terraform-ibm-modules/terraform-ibm-enterprise) and use it to extend your current architecture or create new solutions.",
-      "offering_docs_url": "https://github.com/terraform-ibm-modules/terraform-ibm-enterprise/blob/main/solutions/fully-configurable/README.md",
+      "offering_docs_url": "https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-about-tim",
+      "release_notes_url": "https://github.com/terraform-ibm-modules/terraform-ibm-enterprise/releases",
       "offering_icon_url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-enterprise/main/images/enterprise.svg",
       "provider_name": "IBM",
       "features": [


### PR DESCRIPTION

### Description

This PR updates the `ibm_catalog.json` file for the `community DA tile` and includes the following changes:
- Updates the `offering_docs_url` link.
- Adds a new `release_notes_url` key with a link to the GitHub release notes.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Update `offering_docs_url` link and add the `release_notes_url` in `ibm_catalog.json`.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
